### PR TITLE
Add Trivy image vulnerability scanning to CI pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build_beta.yaml
+++ b/.github/workflows/build_beta.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - beta-*
+  workflow_dispatch:
 jobs:
   build-io:
     name: Beta Deployment
@@ -23,6 +24,7 @@ jobs:
         id: docker_tag
         run: |
           commit_tag=${GITHUB_REF#refs/*/}
+          commit_tag=${commit_tag//\//-}
           echo "tag=${commit_tag}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
       - name: Verify tag
         run: echo ${{ steps.docker_tag.outputs.tag }}
@@ -32,16 +34,31 @@ jobs:
           registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
-      - name: Build and push
+      - name: Build image
         id: docker_build
         uses: docker/build-push-action@v5
         with:
-          push: true
+          push: false
+          load: true
           pull: true
           no-cache: true
           build-args: |
             RUN_AS_USER=plaid
-          tags: us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:latest,us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
+          tags: |
+            us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:latest
+            us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
+          format: table
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+      - name: Push image
+        run: |
+          docker push us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
+          docker push us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:latest
 
       - name: Checkout GitOps Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build_beta.yaml
+++ b/.github/workflows/build_beta.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - beta-*
-  workflow_dispatch:
 jobs:
   build-io:
     name: Beta Deployment
@@ -48,13 +47,14 @@ jobs:
             us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:latest
             us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
           format: table
           exit-code: '0'
           ignore-unfixed: true
           severity: CRITICAL,HIGH
+          cache: true
       - name: Push image
         run: |
           docker push us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}

--- a/.github/workflows/build_io.yaml
+++ b/.github/workflows/build_io.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   build-io:
     name: IO Deployment
@@ -23,6 +24,7 @@ jobs:
         id: docker_tag
         run: |
           commit_tag=${GITHUB_REF#refs/*/}
+          commit_tag=${commit_tag//\//-}
           echo "tag=${commit_tag}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
       - name: Verify tag
         run: echo ${{ steps.docker_tag.outputs.tag }}
@@ -32,16 +34,31 @@ jobs:
           registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
-      - name: Build and push
+      - name: Build image
         id: docker_build
         uses: docker/build-push-action@v5
         with:
-          push: true
+          push: false
+          load: true
           pull: true
           no-cache: true
           build-args: |
             RUN_AS_USER=plaid
-          tags: us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:latest,us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
+          tags: |
+            us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:latest
+            us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
+          format: table
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+      - name: Push image
+        run: |
+          docker push us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
+          docker push us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:latest
 
       - name: Checkout GitOps Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build_io.yaml
+++ b/.github/workflows/build_io.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 jobs:
   build-io:
     name: IO Deployment
@@ -48,13 +47,14 @@ jobs:
             us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:latest
             us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
       - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}
           format: table
           exit-code: '0'
           ignore-unfixed: true
           severity: CRITICAL,HIGH
+          cache: true
       - name: Push image
         run: |
           docker push us-docker.pkg.dev/plaidcloud-build/us-plaidcloud/redistomp:${{ steps.docker_tag.outputs.tag }}

--- a/.github/workflows/pr_trivy.yaml
+++ b/.github/workflows/pr_trivy.yaml
@@ -1,0 +1,33 @@
+name: Trivy Security Scan
+on:
+  pull_request:
+    branches:
+      - main
+      - beta-*
+jobs:
+  trivy:
+    name: Trivy Image Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build image for scanning
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          pull: true
+          build-args: |
+            RUN_AS_USER=plaid
+          tags: redistomp:pr-scan
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: redistomp:pr-scan
+          format: table
+          exit-code: '0'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          cache: true


### PR DESCRIPTION
## What this does

Adds Trivy vulnerability scanning to both PR and build CI workflows.

## Trivy scan mode — currently informational in all workflows

Both the PR scan and the post-build scan run with exit-code 0 (informational). Findings are reported in the job log but the pipeline is not blocked. This is intentional while the team works through any existing CVEs.

To make scans blocking: change exit-code from 0 to 1 in the relevant workflow file (pr_trivy.yaml, build_io.yaml, build_beta.yaml, or all three).

## Changes

New: pr_trivy.yaml - runs on every PR to main or beta-*
- Builds the image locally (no push, no registry login needed)
- Scans with Trivy (informational, CRITICAL/HIGH fixable CVEs)
- Gives developers visibility into CVEs before merging
- Runs alongside existing pr_lint.yaml check

Updated: build_io.yaml and build_beta.yaml - runs after merge on push
- Build and push step split into: Build image / Scan with Trivy / Push image
- Slash sanitization added to tag generation for branch names containing slashes
- Serves as a post-merge safety net

New: dependabot.yml - weekly Dependabot PRs for GitHub Actions version updates

All workflows: trivy-action pinned to v0.36.0 (not @master) with DB caching enabled

## Merge steps

1. Review and approve this PR
2. Merge into main
3. Beta deployments pick up the change on next push to any beta-* branch
4. When ready to enforce as a gate: change exit-code from 0 to 1
