### PR TITLE
Fix /alive RecursionError: upgrade redis-py 5.2.1 -> 7.1.1 (+ dep refresh, ruff/uv lint)

### DIFF
--- a/.github/workflows/pr_lint.yaml
+++ b/.github/workflows/pr_lint.yaml
@@ -10,29 +10,34 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Ensure python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Acquire list of changed python files
         id: all-python-files
         continue-on-error: true
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             **/*.py
       - name: Install Ubuntu dependencies
         run: sudo apt-get update; sudo apt-get install -y curl
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          # Install a specific version of uv.
+          version: "0.11.10"
       - name: Install dependencies
-        run: pip install -r requirements.txt; pip install -q pylint==${{ secrets.PYLINT_VERSION }}; pip install -q liccheck;
+        run: uv pip install --system -r requirements.txt; uv pip install --system -q ruff;
       - name: License Checker
         uses: andersy005/gh-action-py-liccheck@main
         with:
           strategy-ini-file: ./liccheck.ini
           level: cautious
           requirements-txt-file: ./requirements.txt
-          liccheck-version: ${{ secrets.LICCHECK_VERSION }}
+          liccheck-version: ${{ vars.LICCHECK_VERSION }}
       - name: Install ReviewDog
         uses: reviewdog/action-setup@v1
       - name: Check Lint Warnings
@@ -40,9 +45,9 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pylint -s n -f text -d E,R,C ${{ steps.all-python-files.outputs.all_changed_files }} 2>&1 | reviewdog -efm="%f:%l:%c: %m" -name="PyLint Warnings" -reporter=github-check -level=warning
+          ruff check --output-format=concise --exit-zero ${{ steps.all-python-files.outputs.all_changed_files }} 2>&1 | reviewdog -efm="%f:%l:%c: %m" -name="Ruff Warnings" -reporter=github-check -level=warning
       - name: Check Lint Errors
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pylint -s n -f text -E redis_stomp 2>&1 | reviewdog -efm="%f:%l:%c: %m" -name="PyLint Errors" -reporter=github-check -filter-mode=nofilter -fail-on-error
+          ruff check --output-format=concise --exit-zero --select=E9,F63,F7,F82 redis_stomp | reviewdog -efm="%f:%l:%c: %m" -name="Ruff Errors" -reporter=github-check -filter-mode=nofilter -fail-level=error

--- a/liccheck.ini
+++ b/liccheck.ini
@@ -5,14 +5,19 @@ authorized_licenses:
         3-clause bsd
         3-clause bsd <http://www.opensource.org/licenses/bsd-license.php>
         bsd
+        bsd-2-clause
         bsd 3-clause
         bsd-3-clause
+        bsd-3-clause and 0bsd and mit and zlib and cc0-1.0
         new bsd
         bsd license
         new bsd license
         simplified bsd
         apache
         apache 2.0
+        apache-2.0
+        apache-2.0 and bsd-2-clause
+        apache-2.0 and mit
         apache license 2.0
         apache licence v2.0
         apache license, version 2.0
@@ -20,6 +25,7 @@ authorized_licenses:
         apache software license
         asl 2
         cc0 1.0 universal (cc0 1.0) public domain dedication
+        cmu license (mit-cmu)
         hpnd
         historical permission notice and disclaimer (hpnd)
         gnu library or lesser general public license (lgpl)
@@ -28,21 +34,32 @@ authorized_licenses:
         gnu lesser general public license v3 (lgplv3)
         gnu lgpl
         lgpl
+        lgpl-2.1
         lgpl with exceptions or zpl
+        lgpl-3.0-only
         isc
         isc license
         isc license (iscl)
         mit
         mit/x11
+        mit and psf-2.0
+        mit and python-2.0
         mit license
+        mit no attribution license (mit-0)
+        mit-cmu
         mozilla public license
         mozilla public license 1.1 (mpl 1.1)
         mozilla public license 2.0 (mpl 2.0)
         mpl-2.0
+        mpl-2.0 and mit
+        psf-2.0
         psfl
         python software foundation
         python software foundation license
+        the unlicense (unlicense)
+        unlicense
         zpl 2.1
+        zpl-2.1
         zope public
 
 unauthorized_licenses:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-anyio==4.8.0
+anyio==4.14.1
 coilmq@git+https://github.com/rad-pat/coilmq.git@asyncio#egg=coilmq
-redis==5.2.1
-starlette==0.45.3
-uvicorn==0.34.0
-uvloop==0.21.0
-websockets==14.2
+redis==7.1.1
+setuptools==81.0.0  # held back at 81.0.0 for pkg_resources issues (needed by liccheck)
+starlette==1.3.1
+uvicorn==0.41.0
+uvloop==0.22.1
+websockets==15.0.1


### PR DESCRIPTION
## Summary

A pod in namespace `pw-bug-fixes` hit `RecursionError: maximum recursion depth exceeded` (six times, all on the `/alive` probe) while Redis at `plaid-redis-proxy:6380` was briefly unreachable during pod startup. This PR fixes the root cause and refreshes the dependency stack, plus switches the lint workflow to uv + ruff to match the plaid repo.

## Root cause

The recursion is a **redis-py 5.2.1 bug**, entered from `alive_probe` (`redis_stomp/main.py:110`) calling `ping()`. When a connection is unhealthy and all three of these are configured — as they are in `redis_connector.py` — redis-py recurses without bound:

- `health_check_interval=3` (`redis_connector.py:16,349`)
- `retry=Retry(FullJitterBackoff(), 1)` — 1 retry (`redis_connector.py:350`)
- `client_name=CLIENT_NAME` (`redis_connector.py:351`)

The cycle, once per stack frame:

```
on_connect() -> CLIENT SETNAME          (because client_name is set)
  -> send_packed_command -> check_health (because health_check_interval is set)
    -> retry.call_with_retry(_send_ping) (retries=1)
      -> _send_ping -> PING -> read_response fails (server closed the socket)
      -> retry calls _ping_failed -> disconnect()   (clears the socket)
      -> retry re-runs _send_ping -> send_packed_command finds no socket
        -> connect() -> on_connect() -> ...   # back to the top, forever
```

`next_health_check` never advances (the PING never succeeds), so every reconnect re-fires a health check. Because the proxy closes the connection immediately (not a slow timeout), the stack blows in milliseconds.

redis-py 7.1.1 fixes this: `on_connect` sends its setup commands with `check_health=False`, and a mid-command reconnect goes through `connect_check_health(check_health=False)` — both break the loop.

## Verification (done locally)

- **Reproduced** the RecursionError under `redis==5.2.1` using RediStomp's exact connection kwargs against an accept-then-immediately-close TCP server (the incident condition).
- Under **`redis==7.1.1`** the same setup yields a clean `ConnectionError` — no recursion.
- **API compatibility**: `redis_connector.py` builds sync/async single-instance, sentinel (`master_for`/`slave_for`), and cluster clients cleanly on 7.1.1; `Retry.update_supported_errors` and `redis.asyncio.sentinel.MasterNotFoundError` still resolve. (One non-blocking deprecation: `retry_on_timeout` is deprecated since redis 6.0 and now redundant — left as-is for a follow-up.)
- **End-to-end**: installed the full `requirements.txt` (coilmq from git) and drove `GET /alive` via Starlette's `TestClient` against the recursion-trigger fake Redis — the app returns a clean error response instead of recursing.
- **liccheck**: reproduced the CI license failures locally and confirmed the `liccheck.ini` + `setuptools` changes below make the CAUTIOUS check pass (17 packages authorized, exit 0).

## Changes

**`requirements.txt`** (commit 1) — headline fix plus a refresh to versions already proven in `plaid`:

| package | before | after |
|---|---|---|
| redis | 5.2.1 | **7.1.1** |
| anyio | 4.8.0 | 4.14.1 |
| starlette | 0.45.3 | 1.3.1 |
| uvicorn | 0.34.0 | 0.41.0 |
| uvloop | 0.21.0 | 0.22.1 |
| websockets | 14.2 | 15.0.1 |

Also pins `setuptools==81.0.0` (as plaid does) — uv doesn't pull setuptools in like pip did, and liccheck needs `pkg_resources`; newer setuptools drops it.

**`liccheck.ini`** (commit 1) — the refreshed transitive deps now report SPDX-style licenses (`packaging` → `Apache-2.0 OR BSD-2-Clause`, `typing-extensions` → `PSF-2.0`) that the old list didn't recognize. Aligned the `[Licenses]` block with plaid's so the CAUTIOUS check passes; RediStomp's `[Authorized Packages]` is unchanged.

**`.github/workflows/pr_lint.yaml`** (commit 2) — mirror plaid's lint pipeline: install deps with `uv` instead of pip, lint with `ruff` instead of pylint, and read the liccheck version from `vars.LICCHECK_VERSION` (was `secrets.…`). plaid-app-specific steps (Semgrep, tenant-upgrade check) intentionally not included.

## Notes
- `websockets` is pinned to 15.0.1 to stay on the combination proven with uvicorn 0.41 in plaid; RediStomp has no langgraph `<16` constraint, so a later bump is possible once validated.
- `uvloop` is Linux-only (used only via uvicorn auto-detect in the container); it can't be installed on Windows, so local verification ran without it (it was licensed OK in CI).
- CI is green: Lint (uv + ruff + liccheck), Ruff Errors, and Trivy all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
