### PR TITLE
Silence websockets legacy DeprecationWarnings via uvicorn websockets-sansio

### DIFF
--- a/redis_stomp/main.py
+++ b/redis_stomp/main.py
@@ -132,7 +132,10 @@ def main():
     try:
         LOGGING_CONFIG["formatters"]["default"]["fmt"] = "%(asctime)s [%(name)s] %(levelprefix)s %(message)s"
         app.state.redis_url = args.redis
-        uvicorn.run(app, host="0.0.0.0", port=args.port, access_log=False, proxy_headers=True, forwarded_allow_ips='*', log_level=logging.getLevelNamesMapping()[LOG_LEVEL])
+        # ws="websockets-sansio" uses uvicorn's modern websockets implementation;
+        # the default ("auto") selects the legacy impl, which emits DeprecationWarnings
+        # about websockets.legacy / WebSocketServerProtocol on startup and per connection.
+        uvicorn.run(app, host="0.0.0.0", port=args.port, access_log=False, proxy_headers=True, forwarded_allow_ips='*', ws="websockets-sansio", log_level=logging.getLevelNamesMapping()[LOG_LEVEL])
     except KeyboardInterrupt:
         pass
     except Exception as e:


### PR DESCRIPTION
## Summary

After the dependency refresh (#16), the service still logs three `DeprecationWarning`s on startup and on each `/ws` connection:

```
websockets/legacy/__init__.py:6: DeprecationWarning: websockets.legacy is deprecated
uvicorn/protocols/websockets/websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
websockets/legacy/server.py:1178: DeprecationWarning: remove second argument of ws_handler
```

These are emitted by uvicorn's **legacy** websockets implementation (`websockets_impl`), which the default `ws="auto"` selects. uvicorn 0.35+ ships a modern implementation, **`websockets-sansio`**, built on the current websockets API that never imports `websockets.legacy`. This PR selects it in the `uvicorn.run(...)` call.

One line of behaviour change; no dependency change (websockets 15.0.1 and uvicorn 0.41.0 already provide it).

## Verification

Ran the **real `main.py` entrypoint** under `python -W default` (same as the container's `-Wdefault`) and drove a live `/ws` handshake with a `websockets` client:

- **Before** (`ws=auto`): all three warnings present; handshake works.
- **After** (`ws=websockets-sansio`): **no warnings**; the `v11.stomp` subprotocol still negotiates, a text (heartbeat) frame is delivered, and the connection closes cleanly.

Startup log after the change is identical to production minus the three warning blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
