### PR TITLE
Add test suite (+ fix a coroutine leak it uncovered)

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -1,0 +1,28 @@
+name: Test RediStomp Service
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  pytest:
+    name: Run pytest suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Ensure python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Install Ubuntu dependencies
+        run: sudo apt-get update; sudo apt-get install -y curl git
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          # Install a specific version of uv.
+          version: "0.11.10"
+      - name: Install dependencies
+        run: uv pip install --system -r requirements.txt -r test-requirements.txt
+      - name: Run pytest
+        run: pytest -v --tb=short

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # RediStomp
 
 RediStomp is a simple Websocket wrapper around Redis Pub/Sub to allow delivery of messages via STOMP protocol
+
+## Running the tests
+
+The test suite is hermetic — it needs no real Redis and makes no external
+network calls (Redis is faked with `fakeredis`, and connection-failure paths use
+a local throwaway socket server).
+
+```bash
+pip install -r requirements.txt -r test-requirements.txt
+pytest
+```
+
+Notes:
+- `requirements.txt` pins `uvloop`, which is Linux/macOS only. On Windows,
+  install the two dependency files with `uvloop` filtered out
+  (nothing in the test suite needs it); CI runs the full suite on Linux.
+- The suite runs on every pull request via `.github/workflows/pr_test.yaml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,13 @@ build-backend = "setuptools.build_meta"
 line-length = 125
 target-version = ['py311']
 skip-string-normalization = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+# Backstop so a regression that reintroduces a hang can't wedge the suite.
+timeout = 60
+markers = [
+    "integration: end-to-end tests that drive the app over a websocket",
+]

--- a/redis_stomp/main.py
+++ b/redis_stomp/main.py
@@ -132,7 +132,10 @@ def main():
     try:
         LOGGING_CONFIG["formatters"]["default"]["fmt"] = "%(asctime)s [%(name)s] %(levelprefix)s %(message)s"
         app.state.redis_url = args.redis
-        uvicorn.run(app, host="0.0.0.0", port=args.port, access_log=False, proxy_headers=True, forwarded_allow_ips='*', log_level=logging.getLevelNamesMapping()[LOG_LEVEL])
+        # ws="websockets-sansio" uses uvicorn's modern websockets implementation;
+        # the default ("auto") selects the legacy impl, which emits DeprecationWarnings
+        # about websockets.legacy / WebSocketServerProtocol on startup and per connection.
+        uvicorn.run(app, host="0.0.0.0", port=args.port, access_log=False, proxy_headers=True, forwarded_allow_ips='*', ws="websockets-sansio", log_level=logging.getLevelNamesMapping()[LOG_LEVEL])
     except KeyboardInterrupt:
         pass
     except Exception as e:

--- a/redis_stomp/pubsub/topic.py
+++ b/redis_stomp/pubsub/topic.py
@@ -105,34 +105,39 @@ class RedisTopicManager(TopicManager):
     async def next_message(self):
         # ToDo: This could be done by registering a callback on subscribe which might be more favorable, I dunno
         # await redis_pubsub.subscribe(**{ACTIVITY_CHANNEL: on_message})
-        while not self._closing:
-            if not self._redis.subscribed:
-                await asyncio.sleep(0.5)
-                continue
-            message = await asyncio.to_thread(self._redis.get_message, ignore_subscribe_messages=True, timeout=0.5)
-            # get_message with timeout=None can return None
-            if message:
-                # print(repr(message))
-                # Lookup the subscriptions by pattern/channel
-                dest = message['channel'] if message['type'] == 'message' else message['pattern']
+        # Wrapped in try/finally so that _closed is set however this coroutine
+        # exits. On websocket disconnect the enclosing task group cancels this
+        # task, which would otherwise skip the post-loop assignment and leave
+        # close() waiting on _closed forever (leaking the coroutine).
+        try:
+            while not self._closing:
+                if not self._redis.subscribed:
+                    await asyncio.sleep(0.5)
+                    continue
+                message = await asyncio.to_thread(self._redis.get_message, ignore_subscribe_messages=True, timeout=0.5)
+                # get_message with timeout=None can return None
+                if message:
+                    # print(repr(message))
+                    # Lookup the subscriptions by pattern/channel
+                    dest = message['channel'] if message['type'] == 'message' else message['pattern']
 
-                bad_subscribers = set()
-                for subscriber in await self._subscriptions.subscribers(dest):
-                    frame = Frame(cmd=MESSAGE)
-                    frame.headers.setdefault('message-id', str(uuid.uuid4()))
-                    frame.headers['destination'] = TOPIC_PREFIX + message['channel']
-                    frame.headers["subscription"] = subscriber.id
-                    frame.body = message['data']
-                    try:
-                        await subscriber.connection.send_frame(frame)
-                    except:
-                        self.log.exception(
-                            "Error delivering message to subscriber %s; client will be disconnected." % subscriber)
-                        # We queue for deletion so we are not modifying the topics dict
-                        # while iterating over it.
-                        bad_subscribers.add(subscriber)
+                    bad_subscribers = set()
+                    for subscriber in await self._subscriptions.subscribers(dest):
+                        frame = Frame(cmd=MESSAGE)
+                        frame.headers.setdefault('message-id', str(uuid.uuid4()))
+                        frame.headers['destination'] = TOPIC_PREFIX + message['channel']
+                        frame.headers["subscription"] = subscriber.id
+                        frame.body = message['data']
+                        try:
+                            await subscriber.connection.send_frame(frame)
+                        except:
+                            self.log.exception(
+                                "Error delivering message to subscriber %s; client will be disconnected." % subscriber)
+                            # We queue for deletion so we are not modifying the topics dict
+                            # while iterating over it.
+                            bad_subscribers.add(subscriber)
 
-                for s in bad_subscribers:
-                    await self.unsubscribe(s.connection, dest, id=s.id)
-
-        self._closed = True
+                    for s in bad_subscribers:
+                        await self.unsubscribe(s.connection, dest, id=s.id)
+        finally:
+            self._closed = True

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,6 @@
+# Test-only dependencies. Install with:  pip install -r requirements.txt -r test-requirements.txt
+pytest==9.1.1
+pytest-asyncio==1.4.0
+pytest-timeout==2.4.0
+httpx==0.28.1
+fakeredis==2.36.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,87 @@
+"""Shared fixtures for the RediStomp test suite.
+
+The tests are hermetic: no real Redis and no external network are required.
+Redis is either faked with ``fakeredis`` or replaced by a local TCP server that
+mimics an unreachable/broken backend.
+"""
+import os
+import socket
+import sys
+import threading
+
+import pytest
+
+# Make the ``redis_stomp`` package importable when running from the repo root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Patch ``connect`` in main + topic modules to hand back fakeredis clients.
+
+    Returns the shared ``FakeServer`` so a test can build its own publisher
+    client that talks to the same in-memory instance.
+    """
+    import fakeredis
+    import redis_stomp.main as main_mod
+    import redis_stomp.pubsub.topic as topic_mod
+
+    server = fakeredis.FakeServer()
+
+    def fake_connect(redis_url, *args, decode_responses=False, **kwargs):
+        return fakeredis.FakeStrictRedis(server=server, decode_responses=decode_responses)
+
+    monkeypatch.setattr(main_mod, "connect", fake_connect)
+    monkeypatch.setattr(topic_mod, "connect", fake_connect)
+    return server
+
+
+@pytest.fixture
+def accept_close_server():
+    """A TCP server that accepts a connection then immediately closes it.
+
+    This is the exact condition that drove the redis-py 5.2.1 recursion bug:
+    the socket connects, but every read fails at once. Yields ``(host, port)``.
+    """
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(50)
+    stop = threading.Event()
+
+    def serve():
+        while not stop.is_set():
+            srv.settimeout(0.5)
+            try:
+                conn, _ = srv.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    host, port = srv.getsockname()
+    try:
+        yield host, port
+    finally:
+        stop.set()
+        try:
+            srv.close()
+        except OSError:
+            pass
+        thread.join(timeout=2)
+
+
+@pytest.fixture
+def dead_port():
+    """Return a port with nothing listening on it (connections are refused)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,106 @@
+"""Tests for the Starlette app in redis_stomp.main: /alive and the /ws bridge."""
+import time
+
+import fakeredis
+import pytest
+import redis
+from starlette.testclient import TestClient
+
+from redis_stomp.main import app
+
+NULL = "\x00"
+
+
+def _frame(command, headers=None, body=""):
+    lines = [command] + [f"{k}:{v}" for k, v in (headers or {}).items()]
+    return "\n".join(lines) + "\n\n" + body + NULL
+
+
+def _recv_frame(ws):
+    """Receive the next STOMP frame, skipping bare-newline heartbeats."""
+    while True:
+        data = ws.receive_text()
+        if data.strip("\n") == "":
+            continue
+        return data
+
+
+def _parse(raw):
+    raw = raw.rstrip(NULL)
+    head, _, body = raw.partition("\n\n")
+    lines = head.split("\n")
+    headers = dict(line.split(":", 1) for line in lines[1:] if line)
+    return lines[0], headers, body
+
+
+def test_alive_ok_with_reachable_redis(fake_redis):
+    app.state.redis_url = "redis://fake"
+    with TestClient(app) as client:
+        resp = client.get("/alive")
+    assert resp.status_code == 200
+
+
+def test_alive_returns_500_when_redis_unreachable(dead_port):
+    # Real redis_connector.connect() against a refused port -> clean failure -> 500.
+    app.state.redis_url = f"redis://127.0.0.1:{dead_port}/0"
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/alive")
+    assert resp.status_code == 500
+
+
+def test_alive_does_not_recurse(accept_close_server):
+    """Regression guard for the redis-py 5.2.1 health-check recursion.
+
+    Uses the real connect() (health_check_interval + retry + client_name -- the
+    exact trigger) against an accept-then-close server. Under redis 7.1.1 this
+    must surface a normal error, never RecursionError.
+    """
+    host, port = accept_close_server
+    app.state.redis_url = f"redis://{host}:{port}/0"
+    with TestClient(app, raise_server_exceptions=True) as client:
+        with pytest.raises(BaseException) as excinfo:
+            client.get("/alive")
+    assert not isinstance(excinfo.value, RecursionError)
+    # and it is a normal redis/connection error
+    assert isinstance(excinfo.value, (redis.RedisError, OSError))
+
+
+@pytest.mark.integration
+def test_ws_stomp_connect_returns_connected(fake_redis):
+    app.state.redis_url = "redis://fake"
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws", subprotocols=["v11.stomp"]) as ws:
+            ws.send_text(_frame("CONNECT", {"accept-version": "1.1", "host": "localhost"}))
+            command, headers, _ = _parse(_recv_frame(ws))
+            assert command == "CONNECTED"
+            assert headers.get("version") == "1.1"
+            ws.close()
+
+
+@pytest.mark.integration
+def test_ws_redis_publish_arrives_as_message_frame(fake_redis):
+    """The real bridge: a redis publish to a subscribed topic must reach the
+    websocket client as a STOMP MESSAGE frame."""
+    app.state.redis_url = "redis://fake"
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws", subprotocols=["v11.stomp"]) as ws:
+            ws.send_text(_frame("CONNECT", {"accept-version": "1.1", "host": "localhost"}))
+            assert _parse(_recv_frame(ws))[0] == "CONNECTED"
+
+            ws.send_text(_frame("SUBSCRIBE", {"destination": "/topic/news", "id": "sub-1"}))
+
+            # Publish until the SUBSCRIBE has registered on redis (returns >0 receivers).
+            publisher = fakeredis.FakeStrictRedis(server=fake_redis, decode_responses=True)
+            for _ in range(100):
+                if publisher.publish("news", "hello world") > 0:
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail("SUBSCRIBE never registered a redis subscriber")
+
+            command, headers, body = _parse(_recv_frame(ws))
+            assert command == "MESSAGE"
+            assert headers["destination"] == "/topic/news"
+            assert headers["subscription"] == "sub-1"
+            assert body == "hello world"
+            ws.close()

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,137 @@
+"""Tests for redis_stomp.redis_connector.connect / aio_connect.
+
+These assert the clients are built with the right parameters. No real Redis is
+contacted -- redis-py builds connection pools lazily, and the cluster path is
+stubbed so nothing tries to discover slots.
+"""
+import socket
+
+import pytest
+import redis
+import redis.asyncio
+
+import redis_stomp.redis_connector as rc
+from redis_stomp.redis_connector import connect, aio_connect, HeadlessSentinelSync, HeadlessSentinel
+
+
+def _kwargs(client):
+    return client.connection_pool.connection_kwargs
+
+
+# --- sync single instance --------------------------------------------------
+
+def test_connect_single_kwargs():
+    client = connect("redis://:secret@myhost:6380/3")
+    assert isinstance(client, redis.Redis)
+    ck = _kwargs(client)
+    assert ck["host"] == "myhost"
+    assert ck["port"] == 6380
+    assert ck["db"] == 3
+    assert ck["password"] == "secret"
+    assert ck["health_check_interval"] == rc.REDIS_HEALTH_CHECK_INTERVAL == 3
+    assert ck["client_name"] == rc.CLIENT_NAME
+    assert isinstance(ck["retry"], redis.retry.Retry)
+
+
+def test_connect_socket_timeout_override():
+    assert _kwargs(connect("redis://h:6379", socket_timeout=7))["socket_timeout"] == 7
+
+
+def test_connect_socket_timeout_from_url():
+    assert _kwargs(connect("redis://h:6379?socket_timeout=4"))["socket_timeout"] == 4.0
+
+
+def test_connect_decode_responses_flag():
+    assert _kwargs(connect("redis://h:6379", decode_responses=True))["decode_responses"] is True
+
+
+# --- sync sentinel ---------------------------------------------------------
+
+def test_connect_sentinel_master():
+    client = connect("redis+sentinel://h1:26379,h2:26379/mymaster/0")
+    assert type(client.connection_pool).__name__ == "SentinelConnectionPool"
+    assert client.connection_pool.is_master is True
+
+
+def test_connect_sentinel_slave():
+    client = connect("redis+sentinel://h1:26379,h2:26379/mymaster/0", read_only=True)
+    assert client.connection_pool.is_master is False
+
+
+# --- sync cluster (stubbed so it doesn't try to reach a cluster) -----------
+
+def test_connect_cluster_kwargs(monkeypatch):
+    captured = {}
+
+    def fake_cluster(**kwargs):
+        captured.update(kwargs)
+        return "CLUSTER"
+
+    monkeypatch.setattr(redis, "RedisCluster", fake_cluster)
+    result = connect("redis-cluster://chost:7000")
+    assert result == "CLUSTER"
+    assert captured["host"] == "chost"
+    assert captured["port"] == 7000
+    assert captured["health_check_interval"] == 3
+    assert captured["client_name"] == rc.CLIENT_NAME
+    assert isinstance(captured["retry"], redis.retry.Retry)
+
+
+# --- async single instance -------------------------------------------------
+
+def test_aio_connect_single_kwargs():
+    client = aio_connect("redis://ahost:6379/1")
+    assert isinstance(client, redis.asyncio.Redis)
+    ck = _kwargs(client)
+    assert ck["host"] == "ahost"
+    assert ck["db"] == 1
+    assert ck["client_name"] == rc.CLIENT_NAME
+    assert isinstance(ck["retry"], redis.asyncio.retry.Retry)
+
+
+def test_aio_connect_single_omits_health_check_interval():
+    # Documents a real asymmetry: the async single-instance branch does NOT set
+    # health_check_interval, unlike the sync branch. If this is ever "fixed" to
+    # match, update this test.
+    ck = _kwargs(aio_connect("redis://ahost:6379/0"))
+    assert ck.get("health_check_interval", 0) == 0
+
+
+# --- async cluster (stubbed) ----------------------------------------------
+
+def test_aio_connect_cluster_updates_supported_errors(monkeypatch):
+    captured = {}
+
+    def fake_cluster(**kwargs):
+        captured.update(kwargs)
+        return "AIOCLUSTER"
+
+    monkeypatch.setattr(rc, "RedisCluster", fake_cluster)
+    result = aio_connect("redis-cluster://chost:7000")
+    assert result == "AIOCLUSTER"
+    assert captured["host"] == "chost"
+    assert captured["client_name"] == rc.CLIENT_NAME
+    retry = captured["retry"]
+    # aio_connect calls retry.update_supported_errors(DEFAULT_RETRY_ERRORS)
+    assert redis.ConnectionError in retry._supported_errors
+
+
+# --- headless sentinel DNS expansion --------------------------------------
+
+def test_headless_sentinel_sync_expands_dns(monkeypatch):
+    monkeypatch.setattr(
+        socket, "gethostbyname_ex",
+        lambda host: (host, [], ["10.0.0.1", "10.0.0.2", "10.0.0.3"]),
+    )
+    hs = HeadlessSentinelSync("sentinel-svc", 26379, sentinel_kwargs={})
+    assert hs.headless_host == "sentinel-svc"
+    assert len(hs.sentinels) == 3
+
+
+def test_headless_sentinel_from_headless_host(monkeypatch):
+    monkeypatch.setattr(
+        socket, "gethostbyname_ex",
+        lambda host: (host, [], ["10.0.0.1", "10.0.0.2"]),
+    )
+    hs = HeadlessSentinelSync("svc", 26379, sentinel_kwargs={})
+    assert hs.sentinels_from_headless_host() == ["10.0.0.1", "10.0.0.2"]

--- a/tests/test_main_entrypoint.py
+++ b/tests/test_main_entrypoint.py
@@ -1,0 +1,32 @@
+"""Tests for the main() entrypoint wiring in redis_stomp.main."""
+import sys
+
+import redis_stomp.main as main_mod
+
+
+def test_main_configures_uvicorn(monkeypatch):
+    captured = {}
+
+    def fake_run(app_arg, **kwargs):
+        captured["app"] = app_arg
+        captured.update(kwargs)
+
+    monkeypatch.setattr(main_mod.uvicorn, "run", fake_run)
+    monkeypatch.setattr(
+        sys, "argv",
+        ["redistomp", "--port", "9999", "--redis", "redis://example:6380/0"],
+    )
+
+    main_mod.main()
+
+    assert captured["app"] is main_mod.app
+    assert captured["host"] == "0.0.0.0"
+    assert captured["port"] == 9999
+    assert captured["proxy_headers"] is True
+    assert captured["forwarded_allow_ips"] == "*"
+    assert captured["access_log"] is False
+    # The ws-sansio fix: must use uvicorn's modern websockets implementation
+    # so the legacy DeprecationWarnings don't return.
+    assert captured["ws"] == "websockets-sansio"
+    # The chosen --redis is published on the app for the endpoints to read.
+    assert main_mod.app.state.redis_url == "redis://example:6380/0"

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -1,0 +1,149 @@
+"""Tests for redis_stomp.redis_connector.parse_url."""
+import pytest
+
+from redis_stomp.redis_connector import parse_url
+
+
+# --- single instance -------------------------------------------------------
+
+def test_single_basic():
+    r = parse_url("redis://localhost:6379")
+    assert r.hosts == [("localhost", 6379)]
+    assert r.sentinel is False
+    assert r.cluster is False
+    assert r.headless is False
+    assert r.master is True
+    assert r.service_name is None
+    assert r.database == 0
+    assert r.password is None
+    assert r.socket_timeout == 1  # default when not supplied
+
+
+def test_single_default_port():
+    r = parse_url("redis://localhost")
+    assert r.hosts == [("localhost", 6379)]
+
+
+def test_single_db_from_path():
+    assert parse_url("redis://localhost:6379/2").database == 2
+
+
+def test_multiple_hosts():
+    r = parse_url("redis://h1:6379,h2:6380")
+    assert r.hosts == [("h1", 6379), ("h2", 6380)]
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("redis://user:pass@localhost:6379", "pass"),   # user:password
+        ("redis://:pass@localhost:6379", "pass"),       # password only, leading colon
+        ("redis://pass@localhost:6379", "pass"),        # bare token treated as password
+        ("redis://localhost:6379", None),               # no auth
+    ],
+)
+def test_password_parsing(url, expected):
+    assert parse_url(url).password == expected
+
+
+# --- query-string options --------------------------------------------------
+
+def test_socket_timeout_query():
+    assert parse_url("redis://localhost:6379?socket_timeout=5").socket_timeout == 5.0
+
+
+def test_socket_timeout_last_value_wins():
+    r = parse_url("redis://localhost:6379?socket_timeout=1&socket_timeout=9")
+    assert r.socket_timeout == 9.0
+
+
+def test_quorum_query():
+    assert parse_url("redis://localhost:6379?quorum=2").quorum == 2
+
+
+def test_client_type_slave():
+    assert parse_url("redis://localhost:6379?client_type=slave").master is False
+
+
+def test_client_type_master_default():
+    assert parse_url("redis://localhost:6379").master is True
+
+
+def test_invalid_client_type_raises():
+    with pytest.raises(ValueError):
+        parse_url("redis://localhost:6379?client_type=bogus")
+
+
+# --- sentinel --------------------------------------------------------------
+
+def test_sentinel_basic():
+    r = parse_url("redis+sentinel://h:26379/mymaster/0")
+    assert r.sentinel is True
+    assert r.service_name == "mymaster"
+    assert r.hosts == [("h", 26379)]
+    assert r.database == 0
+
+
+def test_sentinel_default_port():
+    r = parse_url("redis+sentinel://h/mymaster/0")
+    assert r.hosts == [("h", 26379)]  # sentinel default port
+
+
+def test_sentinel_db_from_path():
+    assert parse_url("redis+sentinel://h:26379/mymaster/3").database == 3
+
+
+def test_sentinel_service_name_from_query():
+    r = parse_url("redis+sentinel://h:26379?service_name=mymaster")
+    assert r.service_name == "mymaster"
+
+
+@pytest.mark.parametrize(
+    "scheme", ["redis+sentinel", "sentinel", "sentinel+headless"]
+)
+def test_sentinel_scheme_variants(scheme):
+    r = parse_url(f"{scheme}://h:26379/mymaster/0")
+    assert r.sentinel is True
+
+
+def test_headless_flag():
+    r = parse_url("sentinel+headless://h:26379/mymaster/0")
+    assert r.headless is True
+    assert r.sentinel is True
+
+
+def test_sentinel_without_service_name_raises():
+    with pytest.raises(ValueError):
+        parse_url("redis+sentinel://h:26379")
+
+
+def test_sentinel_single_path_part_raises():
+    # Only "/mymaster" -> no service name is derived (needs 2 path parts) -> error
+    with pytest.raises(ValueError):
+        parse_url("redis+sentinel://h:26379/mymaster")
+
+
+# --- cluster ---------------------------------------------------------------
+
+def test_cluster():
+    r = parse_url("redis-cluster://h:6379")
+    assert r.cluster is True
+    assert r.sentinel is False
+    assert r.hosts == [("h", 6379)]
+
+
+# --- scheme validation -----------------------------------------------------
+
+@pytest.mark.parametrize("url", ["http://h:80", "rediss://h:6379", "amqp://h"])
+def test_unsupported_scheme_raises(url):
+    with pytest.raises(ValueError):
+        parse_url(url)
+
+
+# --- known quirk: ?db= query param is parsed but never applied -------------
+
+@pytest.mark.xfail(reason="db query-string param is parsed into options but never "
+                          "used for `database` (only the URL path sets the db); "
+                          "see redis_connector.parse_url", strict=True)
+def test_db_query_param_should_be_applied():
+    assert parse_url("redis://localhost:6379?db=4").database == 4

--- a/tests/test_topic_manager.py
+++ b/tests/test_topic_manager.py
@@ -1,0 +1,167 @@
+"""Tests for redis_stomp.pubsub.topic.RedisTopicManager.
+
+Uses fakeredis (via the ``fake_redis`` fixture) so pub/sub actually works.
+"""
+import asyncio
+
+import fakeredis
+import pytest
+
+from redis_stomp.pubsub.topic import RedisTopicManager
+
+
+class StubConnection:
+    """Minimal stand-in for a coilmq StompConnection that records sent frames."""
+
+    def __init__(self):
+        self.frames = []
+
+    async def send_frame(self, frame):
+        self.frames.append(frame)
+
+
+# --- destination translation (pure) ---------------------------------------
+
+@pytest.mark.parametrize(
+    "destination,expected",
+    [
+        ("/topic/foo", "foo"),
+        ("/topic/foo.bar", "foo.bar"),
+        ("/topic/a/b", "a/b"),
+        ("/topic/a.#", "a.*"),      # '#' becomes '*' (STOMP wildcard -> redis glob)
+        ("/topic/a.#.b", "a.*.b"),
+        ("not-a-topic", "not-a-topic"),  # non-topic destinations pass through
+    ],
+)
+def test_get_redis_destination(fake_redis, destination, expected):
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    assert tm.get_redis_destination(destination) == expected
+
+
+# --- subscribe / unsubscribe against fakeredis -----------------------------
+
+async def test_subscribe_plain_channel(fake_redis):
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    conn = StubConnection()
+    await tm.subscribe(conn, "/topic/news", id="sub-1")
+    assert "news" in tm._redis.channels
+    assert await tm._subscriptions.subscriber_count("news") == 1
+
+
+async def test_subscribe_wildcard_uses_psubscribe(fake_redis):
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    await tm.subscribe(StubConnection(), "/topic/news.*", id="sub-1")
+    assert "news.*" in tm._redis.patterns
+    assert tm._redis.channels == {}
+
+
+async def test_subscribe_hash_wildcard(fake_redis):
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    await tm.subscribe(StubConnection(), "/topic/a.#", id="sub-1")
+    assert "a.*" in tm._redis.patterns
+
+
+# redis-py only prunes PubSub.channels when the unsubscribe *ack* is read, so we
+# assert the observable contract instead: the manager tells redis to unsubscribe
+# exactly when the last subscriber for a destination leaves.
+
+async def test_unsubscribe_by_destination_calls_redis(fake_redis, monkeypatch):
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    conn = StubConnection()
+    await tm.subscribe(conn, "/topic/news", id="sub-1")
+
+    calls = []
+    monkeypatch.setattr(tm._redis, "unsubscribe", lambda *a: calls.append(a))
+    await tm.unsubscribe(conn, "/topic/news", id="sub-1")
+
+    assert calls == [("news",)]
+    assert await tm._subscriptions.subscriber_count("news") == 0
+
+
+async def test_unsubscribe_by_id_only(fake_redis, monkeypatch):
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    conn = StubConnection()
+    await tm.subscribe(conn, "/topic/news", id="sub-1")
+
+    calls = []
+    monkeypatch.setattr(tm._redis, "unsubscribe", lambda *a: calls.append(a))
+    await tm.unsubscribe(conn, destination=None, id="sub-1")
+
+    assert calls == [("news",)]
+
+
+async def test_unsubscribe_keeps_redis_sub_while_others_remain(fake_redis, monkeypatch):
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    c1, c2 = StubConnection(), StubConnection()
+    await tm.subscribe(c1, "/topic/news", id="a")
+    await tm.subscribe(c2, "/topic/news", id="b")
+
+    calls = []
+    monkeypatch.setattr(tm._redis, "unsubscribe", lambda *a: calls.append(a))
+    await tm.unsubscribe(c1, "/topic/news", id="a")
+
+    assert calls == []  # c2 is still subscribed, so redis stays subscribed
+    assert await tm._subscriptions.subscriber_count("news") == 1
+
+
+async def test_unsubscribe_wildcard_calls_punsubscribe(fake_redis, monkeypatch):
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    conn = StubConnection()
+    await tm.subscribe(conn, "/topic/news.*", id="sub-1")
+
+    calls = []
+    monkeypatch.setattr(tm._redis, "punsubscribe", lambda *a: calls.append(a))
+    await tm.unsubscribe(conn, "/topic/news.*", id="sub-1")
+
+    assert calls == [("news.*",)]
+
+
+# --- end-to-end message delivery ------------------------------------------
+
+# --- teardown regression: the coroutine-leak bug -------------------------
+
+async def test_next_message_sets_closed_when_cancelled(fake_redis):
+    """Regression guard: on disconnect the enclosing task group cancels
+    next_message. It must still mark itself closed, otherwise close() waits on
+    _closed forever and leaks the coroutine (the original bug)."""
+    tm = RedisTopicManager(StubConnection(), "redis://x")
+    task = asyncio.create_task(tm.next_message())
+    await asyncio.sleep(0.1)  # let it enter the loop
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert tm._closed is True
+    # close() must now return promptly rather than spinning on _closed.
+    await asyncio.wait_for(tm.close(), timeout=2)
+
+
+async def test_message_is_delivered_as_stomp_frame(fake_redis):
+    from coilmq.util.frames import MESSAGE
+
+    conn = StubConnection()
+    tm = RedisTopicManager(conn, "redis://x")
+    await tm.subscribe(conn, "/topic/news", id="sub-1")
+
+    publisher = fakeredis.FakeStrictRedis(server=fake_redis, decode_responses=True)
+
+    task = asyncio.create_task(tm.next_message())
+    try:
+        await asyncio.sleep(0.1)  # let next_message enter its get_message loop
+        publisher.publish("news", "hello world")
+        for _ in range(50):
+            if conn.frames:
+                break
+            await asyncio.sleep(0.1)
+    finally:
+        tm._closing = True
+        await asyncio.wait_for(task, timeout=3)
+
+    assert len(conn.frames) == 1
+    frame = conn.frames[0]
+    assert frame.cmd == MESSAGE
+    assert frame.body == "hello world"
+    assert frame.headers["destination"] == "/topic/news"
+    assert frame.headers["subscription"] == "sub-1"
+    assert "message-id" in frame.headers


### PR DESCRIPTION
## Summary

Adds a hermetic `pytest` suite for the package (there was none), wires it into CI, and fixes a real coroutine leak that building the tests uncovered.

> **Stacked on #17** (ws-sansio). Until #17 merges, this PR's diff includes that one commit; `test_main_entrypoint` asserts the `ws="websockets-sansio"` wiring, so the suite depends on it. Rebase/merge after #17.

## The bug the tests found

`RedisTopicManager.close()` deadlocked on **every `/ws` disconnect**, leaking a coroutine each time:

- On disconnect, `dispatch` cancels the task group → `next_message()` is cancelled mid-await → the `self._closed = True` line (which sat *after* the loop) never ran.
- `close()` then looped forever on `while not self._closed`, spinning on `asyncio.sleep(0.1)`.

A naive "handshake succeeds" test passed right over this (TestClient doesn't wait for the server-side teardown). It only showed up once I instrumented teardown with a watchdog. Fix: set `_closed` in a `finally:`. Verified — before: `close()` never returns; after: returns cleanly. First commit, isolated.

## What's covered

Hermetic — no real Redis, no network (Redis faked with `fakeredis`; failure paths use a local throwaway socket):

- **`parse_url`** — schemes, auth forms, multi-host, db, sentinel/cluster/headless, query options, validation. Includes an `xfail(strict)` documenting that the `?db=` query param is parsed but never applied (a real latent bug, flagged not hidden).
- **`connect` / `aio_connect`** — client type + connection kwargs for single/sentinel/cluster, headless DNS expansion.
- **`RedisTopicManager`** — destination translation, subscribe/unsubscribe redis calls, **end-to-end publish → STOMP MESSAGE delivery**, and the cancellation/teardown regression guard.
- **Starlette app** — `/alive` (healthy, unreachable, and the redis-py **recursion regression** against a real accept-then-close socket), and a **real STOMP `CONNECT → CONNECTED → SUBSCRIBE → publish → MESSAGE`** round trip over the websocket.
- **`main()`** — asserts uvicorn is wired with `ws=websockets-sansio` + proxy args.

**61 passed, 1 xfailed** locally in ~3.6s.

## On test quality

These assert *observed* behavior, not assumptions. Proven two ways:
- The `?db=` and health-check-interval asymmetry are `xfail`/documented rather than asserted-as-if-correct.
- Mutation-checked the teardown guard: reverting only the `topic.py` fix makes `test_next_message_sets_closed_when_cancelled` fail (`assert False is True`), while the end-to-end `/ws` tests still pass against the buggy code — confirming the targeted test is the one with teeth.

## Other findings (not fixed here — flagging for follow-up)

- `parse_url` ignores the `?db=` query param (only the URL path sets the db).
- `aio_connect` single-instance omits `health_check_interval` (the sync path sets it) — an asymmetry, documented in a test.
- `retry_on_timeout=True` is deprecated since redis 6.0 (harmless warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
