### PR TITLE
Remove dead async connector code (aio_connect + async HeadlessSentinel)

### DIFF
--- a/redis_stomp/main.py
+++ b/redis_stomp/main.py
@@ -18,10 +18,9 @@ from coilmq.asyncio.server import StompConnection
 from coilmq.asyncio.protocol import STOMP11
 from coilmq.util.frames import FrameBuffer
 from coilmq.exception import ClientDisconnected
-from redis.asyncio import Redis
 
 from redis_stomp.pubsub.topic import RedisTopicManager
-from redis_stomp.redis_connector import aio_connect, connect
+from redis_stomp.redis_connector import connect
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 

--- a/redis_stomp/pubsub/topic.py
+++ b/redis_stomp/pubsub/topic.py
@@ -7,7 +7,7 @@ from coilmq.asyncio.topic import TopicManager
 from coilmq.asyncio.server import StompConnection
 from coilmq.util.frames import Frame, MESSAGE
 
-from redis_stomp.redis_connector import aio_connect, connect
+from redis_stomp.redis_connector import connect
 
 
 LOGGER = logging.getLogger(__name__)

--- a/redis_stomp/redis_connector.py
+++ b/redis_stomp/redis_connector.py
@@ -5,14 +5,11 @@ from urllib import parse as urlparse
 
 import redis
 import redis.retry
-from redis.asyncio.sentinel import MasterNotFoundError as aioMasterNotFoundError
-from redis.asyncio import Redis, Sentinel, RedisCluster
-from redis.asyncio.retry import Retry
 from redis.backoff import FullJitterBackoff, NoBackoff
 
 R = TypeVar('R', bound=redis.Redis)
 CLIENT_NAME = socket.gethostname().rsplit('-', 2)[0]
-DEFAULT_RETRY_ERRORS = (TimeoutError, socket.timeout, redis.TimeoutError, redis.ConnectionError)  # Needed for async version to add socket timeout
+DEFAULT_RETRY_ERRORS = (TimeoutError, socket.timeout, redis.TimeoutError, redis.ConnectionError)  # retryable errors for the headless sentinel discovery
 REDIS_HEALTH_CHECK_INTERVAL = 3
 
 class ParsedRedisURL(NamedTuple):
@@ -126,67 +123,6 @@ def parse_url(url: str) -> ParsedRedisURL:
         headless=is_headless(),
         quorum=options.get("quorum", 0),
     )
-
-
-class HeadlessSentinel(Sentinel):
-    def __init__(
-        self,
-        headless_host, port,
-        min_other_sentinels=0,
-        sentinel_kwargs=None,
-        **connection_kwargs,
-    ):
-        self.headless_host = headless_host
-        self.port = port
-        super().__init__(
-            sentinels=[(ip, port) for ip in self.sentinels_from_headless_host()],
-            min_other_sentinels=min_other_sentinels,
-            sentinel_kwargs=sentinel_kwargs,
-            **connection_kwargs,
-        )
-
-    def sentinels_from_headless_host(self) -> list[str]:
-        host, alias_list, ip_list = socket.gethostbyname_ex(self.headless_host)
-        return ip_list
-
-    def refresh_sentinels(self):
-        self.sentinels = [
-            Redis(host=ip, port=self.port, **self.sentinel_kwargs)
-            for ip in self.sentinels_from_headless_host()
-        ]
-
-    # async def execute_command(self, *args, **kwargs):
-    #     """
-    #     Execute Sentinel command in sentinel nodes.
-    #     once - If set to True, then execute the resulting command on a single
-    #            node at random, rather than across the entire sentinel cluster.
-    #     """
-    #     try:
-    #         return await super().execute_command(*args, **kwargs)
-    #     except DEFAULT_RETRY_ERRORS:
-    #         if not kwargs.get('sentinels_refreshed', False):
-    #             self.refresh_sentinels()
-    #             kwargs['sentinels_refreshed'] = True
-    #             return await self.execute_command(*args, **kwargs)
-    #         raise
-
-    async def discover_master(self, service_name, has_refreshed: bool = False):
-        try:
-            return await super().discover_master(service_name)
-        except DEFAULT_RETRY_ERRORS + (aioMasterNotFoundError,):
-            if not has_refreshed:
-                self.refresh_sentinels()
-                return await self.discover_master(service_name, True)
-            raise
-
-    async def discover_slaves(self, service_name, has_refreshed: bool = False):
-        try:
-            return await super().discover_slaves(service_name)
-        except DEFAULT_RETRY_ERRORS:
-            if not has_refreshed:
-                self.refresh_sentinels()
-                return await self.discover_slaves(service_name, True)
-            raise
 
 
 class HeadlessSentinelSync(redis.Sentinel):
@@ -348,110 +284,5 @@ def connect(redis_url: str,  read_only: bool = False, socket_timeout: float = No
             socket_timeout=socket_timeout or rinfo.socket_timeout,
             health_check_interval=REDIS_HEALTH_CHECK_INTERVAL,
             retry=redis.retry.Retry(FullJitterBackoff(), 1),
-            client_name=CLIENT_NAME,
-        )
-
-
-def aio_connect(redis_url: str, read_only: bool = False, socket_timeout: float = None,
-                redis_class: Type[Redis] = Redis, decode_responses: bool = False):
-    """Returns an async Redis connection
-
-    Args:
-        redis_url (str): The Redis connection url
-        read_only (bool): If true, the connection will be made to the master node, else to a slave node
-        socket_timeout (float): Socket timeout threshold
-        redis_class (Type[Redis]):
-        decode_responses (bool): Redis connection kwarg for decode_responses
-
-    Returns:
-        redis.asyncio.client.Redis: Redis connection
-    """
-    rinfo = parse_url(redis_url)
-    if rinfo.cluster:
-        host, port = rinfo.hosts[0]
-        cluster_retry = Retry(FullJitterBackoff(), 1)
-        cluster_retry.update_supported_errors(list(DEFAULT_RETRY_ERRORS))   # can't pass retry_on_timeout to async cluster
-        return RedisCluster(
-            host=host,
-            port=port,
-            # client params
-            db=rinfo.database,
-            password=rinfo.password,
-            decode_responses=decode_responses,
-            socket_timeout=socket_timeout or rinfo.socket_timeout,
-            health_check_interval=REDIS_HEALTH_CHECK_INTERVAL,
-            retry=cluster_retry,
-            client_name=CLIENT_NAME,
-        )
-    elif rinfo.sentinel:
-        # We're connecting to a sentinel cluster.
-        if rinfo.headless:
-            # min_retries = max([
-            #     len(socket.getaddrinfo(host, port, type=socket.SOCK_STREAM))
-            #     for host, port in rinfo.hosts
-            # ])
-            sentinel_connection = HeadlessSentinel(
-                rinfo.hosts[0][0],
-                rinfo.hosts[0][1],
-                min_other_sentinels=rinfo.quorum or 0,
-                sentinel_kwargs={
-                    'retry': Retry(NoBackoff(), 3),
-                    'socket_timeout': socket_timeout or rinfo.socket_timeout,
-                    'health_check_interval': REDIS_HEALTH_CHECK_INTERVAL,
-                    'client_name': CLIENT_NAME,
-                },
-                ## connection kwargs that will be applied to masters/slaves if not overridden
-                db=rinfo.database,
-                password=rinfo.password,
-                health_check_interval=REDIS_HEALTH_CHECK_INTERVAL,
-                retry=redis.retry.Retry(FullJitterBackoff(), 1),
-                client_name=CLIENT_NAME,
-            )
-        else:
-            sentinel_connection = Sentinel(
-                rinfo.hosts,
-                sentinel_kwargs={
-                    'retry_on_timeout': True,  # required for retry on socket timeout for the async class
-                    'retry': Retry(NoBackoff(), 3),
-                    'socket_timeout': socket_timeout or rinfo.socket_timeout,
-                    'health_check_interval': REDIS_HEALTH_CHECK_INTERVAL,
-                    'client_name': CLIENT_NAME,
-                },
-                ## connection kwargs that will be applied to masters/slaves if not overridden
-                db=rinfo.database,
-                password=rinfo.password,
-                health_check_interval=REDIS_HEALTH_CHECK_INTERVAL,
-                retry_on_timeout=True,  # required for retry on socket timeout for the async class
-                retry=Retry(FullJitterBackoff(), 1),
-                client_name=CLIENT_NAME,
-            )
-        if read_only:
-            return sentinel_connection.slave_for(
-                rinfo.service_name,
-                redis_class=redis_class,
-                socket_timeout=socket_timeout or rinfo.socket_timeout,
-                decode_responses=decode_responses,
-                client_name=CLIENT_NAME,
-            )
-        else:
-            return sentinel_connection.master_for(
-                rinfo.service_name,
-                redis_class=redis_class,
-                socket_timeout=socket_timeout or rinfo.socket_timeout,
-                decode_responses=decode_responses,
-                client_name=CLIENT_NAME,
-            )
-    else:
-        # Single redis instance
-        host, port = rinfo.hosts[0]
-        return redis_class(
-            host=host,
-            port=port,
-            db=rinfo.database,
-            password=rinfo.password,
-            decode_responses=decode_responses,
-            socket_timeout=socket_timeout or rinfo.socket_timeout,
-            retry_on_timeout=True,  # required for retry on socket timeout for the async class
-            retry=Retry(FullJitterBackoff(), 1),
             client_name=CLIENT_NAME,
         )

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,4 +1,4 @@
-"""Tests for redis_stomp.redis_connector.connect / aio_connect.
+"""Tests for redis_stomp.redis_connector.connect.
 
 These assert the clients are built with the right parameters. No real Redis is
 contacted -- redis-py builds connection pools lazily, and the cluster path is
@@ -8,10 +8,9 @@ import socket
 
 import pytest
 import redis
-import redis.asyncio
 
 import redis_stomp.redis_connector as rc
-from redis_stomp.redis_connector import connect, aio_connect, HeadlessSentinelSync, HeadlessSentinel
+from redis_stomp.redis_connector import connect, HeadlessSentinelSync
 
 
 def _kwargs(client):
@@ -75,45 +74,6 @@ def test_connect_cluster_kwargs(monkeypatch):
     assert captured["health_check_interval"] == 3
     assert captured["client_name"] == rc.CLIENT_NAME
     assert isinstance(captured["retry"], redis.retry.Retry)
-
-
-# --- async single instance -------------------------------------------------
-
-def test_aio_connect_single_kwargs():
-    client = aio_connect("redis://ahost:6379/1")
-    assert isinstance(client, redis.asyncio.Redis)
-    ck = _kwargs(client)
-    assert ck["host"] == "ahost"
-    assert ck["db"] == 1
-    assert ck["client_name"] == rc.CLIENT_NAME
-    assert isinstance(ck["retry"], redis.asyncio.retry.Retry)
-
-
-def test_aio_connect_single_omits_health_check_interval():
-    # Documents a real asymmetry: the async single-instance branch does NOT set
-    # health_check_interval, unlike the sync branch. If this is ever "fixed" to
-    # match, update this test.
-    ck = _kwargs(aio_connect("redis://ahost:6379/0"))
-    assert ck.get("health_check_interval", 0) == 0
-
-
-# --- async cluster (stubbed) ----------------------------------------------
-
-def test_aio_connect_cluster_updates_supported_errors(monkeypatch):
-    captured = {}
-
-    def fake_cluster(**kwargs):
-        captured.update(kwargs)
-        return "AIOCLUSTER"
-
-    monkeypatch.setattr(rc, "RedisCluster", fake_cluster)
-    result = aio_connect("redis-cluster://chost:7000")
-    assert result == "AIOCLUSTER"
-    assert captured["host"] == "chost"
-    assert captured["client_name"] == rc.CLIENT_NAME
-    retry = captured["retry"]
-    # aio_connect calls retry.update_supported_errors(DEFAULT_RETRY_ERRORS)
-    assert redis.ConnectionError in retry._supported_errors
 
 
 # --- headless sentinel DNS expansion --------------------------------------


### PR DESCRIPTION
## Summary

`aio_connect` was imported in `main.py` and `topic.py` but **never called** — RediStomp runs entirely through the synchronous `connect()` (wrapped in `asyncio.to_thread`). This removes it and everything that existed only to support it.

> **Stacked on #18** (which is stacked on #17). This PR also deletes the three `aio_connect` tests added in #18, so it must merge after it. Diff will shrink to just these changes once #17/#18 land.

## Removed
- `aio_connect()` — the unused async connection builder.
- `HeadlessSentinel` (async) — its only caller was `aio_connect`.
- The now-unused `redis.asyncio` imports: `Redis`, `Sentinel`, `RedisCluster`, async `Retry`, `aioMasterNotFoundError`.
- `from redis.asyncio import Redis` in `main.py` (never used).
- The three `aio_connect` unit tests.

## Kept
- The synchronous `connect()` and `HeadlessSentinelSync` — both in active use.
- `DEFAULT_RETRY_ERRORS` — still used by `HeadlessSentinelSync`'s discovery retries (comment updated to reflect that).

## Side benefit
`aio_connect` was the only code passing `retry_on_timeout=True`, so the redis-6.0 deprecation warning it emitted is gone. (This closes one of the two follow-ups noted in #18; the other — `parse_url` ignoring `?db=` — is still open, tracked by the xfail test.)

## Verification
- `redis_connector.py`: 458 → 288 lines; imports cleanly; ruff error-scan and unused-import (F401) checks pass.
- No dangling references to the removed symbols anywhere in `redis_stomp/` or `tests/`.
- Full suite: **58 passed, 1 xfailed** (down from 61 — the 3 async tests removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
